### PR TITLE
Fix display of usage instructions on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ General organisation:
 
 Usage:
 
-  git clone git@github.com:kierdavis/sourcebots-nix-tools.git
-  cd sourcebots-nix-tools
-  nix-build -A PACKAGE
+    git clone git@github.com:kierdavis/sourcebots-nix-tools.git
+    cd sourcebots-nix-tools
+    nix-build -A PACKAGE
 
 See the top-level `default.nix` for a list of packages.


### PR DESCRIPTION
Further indent setup instructions to ensure Github parses them correctly as a code block.